### PR TITLE
Update LDAPLib.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Logaaaaaaaaaa
+# Change Log
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Log
+# Change Logaaaaaaaaaa
 
 ## [Unreleased]
 

--- a/application/libraries/LDAPLib.php
+++ b/application/libraries/LDAPLib.php
@@ -167,7 +167,8 @@ class LDAPLib
 		}
 
 		// LDAP connection
-		$ldapConnection = @ldap_connect($ldapConfigs[self::SERVER], $ldapConfigs[self::PORT]);
+		//$ldapConnection = @ldap_connect($ldapConfigs[self::SERVER], $ldapConfigs[self::PORT]);
+		$ldapConnection = @ldap_connect($ldapConfigs[self::SERVER].':'.$ldapConfigs[self::PORT]);
 		if ($ldapConnection) // if success
 		{
 			// Sets the LDAP protocol version


### PR DESCRIPTION
Hallo liebes Technikum Team,

hier sende ich mal unseren ersten pull request an euch :)
wie vorhin mit Ösi besprochen habe ich die ldap_connect angepasst damit auch der richtige Port genommen wird.
Die Funktion die derzeit verwendet wird ist leider schon deprecated.
https://www.php.net/manual/en/function.ldap-connect.php

Bitte schaut euch das an ob man es so verwenden könnte.
Die config müsste dann z.B. so aussehen:
define('LDAP_SERVER','ldap://xxxxxx.yyyyyyy.at');
define('LDAP_PORT', 3268);
define('LDAP_STARTTLS', true);

Danke und liebe Grüße
Thomas und Michael von FHB
