### PR TITLE
Update gemeinde.class.php

### DIFF
--- a/include/gemeinde.class.php
+++ b/include/gemeinde.class.php
@@ -139,7 +139,7 @@ class gemeinde extends basis_db
 		if($this->db_query($qry))
 		{
 			//naechste ID aus der Sequence holen
-			$qry="SELECT currval('tbl_gemeinde_gemeinde_id_seq') as id;";
+			$qry="SELECT currval('bis.tbl_gemeinde_gemeinde_id_seq') as id;";
 			if($this->db_query($qry))
 			{
 				if($row = $this->db_fetch_object())


### PR DESCRIPTION
Hallo,
wie mit Ösi besprochen bin ich gerade dabei ein Skript zum befüllen der Gemeinde Tabelle zu erstellen.
Wenn ich die gemeinde->save() aufrufe bekomme ich den Fehler:
FEHLER: Relation »tbl_gemeinde_gemeinde_id_seq« existiert nicht

postgres findet den Sequenzer nicht also müsste man bis.xxxx angeben:
SELECT currval('bis.tbl_gemeinde_gemeinde_id_seq');
dann sollte es klappen.

Danke und liebe Grüße
Michael