### PR TITLE
Fhbgld betriebmittel anpassungen

### DIFF
--- a/content/betriebsmitteloverlay.xul.php
+++ b/content/betriebsmitteloverlay.xul.php
@@ -204,7 +204,7 @@ else
 									<row id="betriebsmittel-row-nummer2">
 										<label value="Nummer 2" control="betriebsmittel-textbox-nummer2"/>
 										<hbox>
-					      					<textbox id="betriebsmittel-textbox-nummer2" disabled="true" maxlength="12"/>
+					      					<textbox id="betriebsmittel-textbox-nummer2" disabled="true" maxlength="32"/>
 					      					<spacer flex="1" />
 					      				</hbox>
 									</row>

--- a/include/betriebsmittel.class.php
+++ b/include/betriebsmittel.class.php
@@ -1186,7 +1186,6 @@ class betriebsmittel extends basis_db
 		//Kartennummern die im Hex-Format sind werden umgewandelt
 		if (!is_numeric($kartennummer))
 		{
-			//$kartennummer=substr($kartennummer,strlen($kartennummer)-2,2).substr($kartennummer,strlen($kartennummer)-4,2). substr($kartennummer,strlen($kartennummer)-6,2).substr($kartennummer,0,2);
 			$tmp_kn_str = null;
 			for ($i=0; strlen($kartennummer) > $i; $i+=2) { 
 

--- a/include/betriebsmittel.class.php
+++ b/include/betriebsmittel.class.php
@@ -1186,7 +1186,23 @@ class betriebsmittel extends basis_db
 		//Kartennummern die im Hex-Format sind werden umgewandelt
 		if (!is_numeric($kartennummer))
 		{
-			$kartennummer=substr($kartennummer,strlen($kartennummer)-2,2).substr($kartennummer,strlen($kartennummer)-4,2). substr($kartennummer,strlen($kartennummer)-6,2).substr($kartennummer,0,2);
+			//$kartennummer=substr($kartennummer,strlen($kartennummer)-2,2).substr($kartennummer,strlen($kartennummer)-4,2). substr($kartennummer,strlen($kartennummer)-6,2).substr($kartennummer,0,2);
+			$tmp_kn_str = null;
+			for ($i=0; strlen($kartennummer) > $i; $i+=2) { 
+
+				#wenn die strlen($kartennummer) gerade ist (TW hat 8 Stellen, FHB 14 Stellen)
+				$tmp_kn_str .= substr($kartennummer,strlen($kartennummer)-($i+2),2);
+				
+				//#wenn ich ungerade und der letzte Durchgang ist dann nur mehr die eine Nummer nach vorne
+				//if ((strlen($kartennummer)%2 != 0) && ($i+2 > strlen($kartennummer))) {
+				//	$tmp_kn_str .= substr($kartennummer,strlen($kartennummer)-($i+1),1);
+				//#sonst normal immer 2 stellen nach vorne ruecken
+				//} else {
+				//	$tmp_kn_str .= substr($kartennummer,strlen($kartennummer)-($i+2),2);
+				//}
+			}
+			$kartennummer = $tmp_kn_str;
+			
 			$kartennummer=hexdec( $kartennummer);
 		}
 


### PR DESCRIPTION
Hallo,
wie mit Ösi besprochen die Anapssungen bezüglich der Kartennummer.
erweiterung von betriebsmittel-textbox-nummer2 von 12 auf 32 Stellen
und Anapssung der transform_kartennummer von fixen 8 Stellen auf dynische Länge
Danke und liebe Grüße
Michael-FHB