### PR TITLE
FHB_Verband als Detailinfo

### DIFF
--- a/content/lvplanung/lehrveranstaltungnotenoverlay.xul.php
+++ b/content/lvplanung/lehrveranstaltungnotenoverlay.xul.php
@@ -120,6 +120,10 @@ echo "<?xml-stylesheet href=\"".APP_ROOT."content/bindings.css\" type=\"text/css
 				class="sortDirectionIndicator"
 				sort="rdf:http://www.technikum-wien.at/zeugnisnote/rdf#studiengang_kz"  onclick="LehrveranstaltungNotenTreeSort()"/>
 			<splitter class="tree-splitter"/>
+			<treecol id="lehrveranstaltung-noten-tree-verband" label="Verband" flex="2" hidden="true" persist="hidden, width, ordinal"
+				class="sortDirectionIndicator"
+				sort="rdf:http://www.technikum-wien.at/zeugnisnote/rdf#verband" />						
+            <splitter class="tree-splitter"/>
             <treecol id="lehrveranstaltung-noten-tree-studiengang_kz_lv" label="LehrveranstaltungStudiengang_kz" flex="1" hidden="true" persist="hidden, width, ordinal"
                      class="sortDirectionIndicator"
                      sort="rdf:http://www.technikum-wien.at/zeugnisnote/rdf#studiengang_kz_lv"  onclick="LehrveranstaltungNotenTreeSort()"/>
@@ -151,6 +155,7 @@ echo "<?xml-stylesheet href=\"".APP_ROOT."content/bindings.css\" type=\"text/css
 						<treecell label="rdf:http://www.technikum-wien.at/zeugnisnote/rdf#lehrveranstaltung_id"/>
 						<treecell label="rdf:http://www.technikum-wien.at/zeugnisnote/rdf#studiengang"/>
 						<treecell label="rdf:http://www.technikum-wien.at/zeugnisnote/rdf#studiengang_kz"/>
+						<treecell label="rdf:http://www.technikum-wien.at/zeugnisnote/rdf#verband"/>
 						<treecell label="rdf:http://www.technikum-wien.at/zeugnisnote/rdf#studiengang_kz_lv"/>
 						<treecell label="rdf:http://www.technikum-wien.at/zeugnisnote/rdf#student_semester"/>
 						<treecell label="rdf:http://www.technikum-wien.at/zeugnisnote/rdf#punkte"/>

--- a/rdf/zeugnisnote.rdf.php
+++ b/rdf/zeugnisnote.rdf.php
@@ -118,6 +118,7 @@ foreach ($obj->result as $row)
 				<NOTE:student_vorname><![CDATA['.$benutzer->vorname.']]></NOTE:student_vorname>
 				<NOTE:studiengang><![CDATA['.(isset($stg_arr[$benutzer->studiengang_kz])?$stg_arr[$benutzer->studiengang_kz]:'').']]></NOTE:studiengang>
 				<NOTE:studiengang_kz><![CDATA['.$benutzer->studiengang_kz.']]></NOTE:studiengang_kz>
+				<NOTE:verband><![CDATA['.$benutzer->verband.']]></NOTE:verband>
 				<NOTE:studiengang_lv><![CDATA['.$stg_arr[$lv_obj->studiengang_kz].']]></NOTE:studiengang_lv>
 				<NOTE:studiengang_kz_lv><![CDATA['.$lv_obj->studiengang_kz.']]></NOTE:studiengang_kz_lv>
 				<NOTE:semester_lv><![CDATA['.$lv_obj->semester.']]></NOTE:semester_lv>


### PR DESCRIPTION
Wie im Meeting am 1.2.2022 besprochen. Der Verband als Detailinfo bei den Lehrveranstaltungsnoten als zusätzliche Spalte einblenden. 