### PR TITLE
Fhbgld   bis lehrgangsmeldung

### DIFF
--- a/config/vilesci.config-default.inc.php
+++ b/config/vilesci.config-default.inc.php
@@ -249,8 +249,8 @@ define('BIS_FUNKTIONSCODE_6_ARR', array(
 	'Team'
 ));
 
-// Standortcode fuer Lehrgaenge
-define('BIS_STANDORTCODE_LEHRGAENGE', '0');
+// Standortcode fuer Lehrgaenge - Obsolete da Standort nun aus DB geholt wird
+//define('BIS_STANDORTCODE_LEHRGAENGE', '0');
 
 // bPk Abfrage
 define('BPK_FUER_ALLE_BENUTZER_ABFRAGEN', false);

--- a/vilesci/bis/lehrgangsmeldung.php
+++ b/vilesci/bis/lehrgangsmeldung.php
@@ -58,6 +58,7 @@ else
 $datei='';
 $zaehl=0;
 $lehrgangsname = '';
+$standortcode = null;
 
 $stsem_obj = new studiensemester();
 $stsem_obj->load($ssem);
@@ -158,16 +159,16 @@ if ($stg_kz == '')
 	exit();
 }
 
-// Standortcode
-if (defined('BIS_STANDORTCODE_LEHRGAENGE') && BIS_STANDORTCODE_LEHRGAENGE != '0')
-{
-	$standortcode = BIS_STANDORTCODE_LEHRGAENGE;
-}
-else
-{
-	echo "<H2>Standortcode f&uuml;r Lehrg&auml;nge fehlt.</H2>";
-	exit;
-}
+// Standortcode - Obsolete da Standort nun aus DB geholt wird - auch kein Eintrag in vilesci.config->BIS_STANDORTCODE_LEHRGAENGE noetig
+#####if (defined('BIS_STANDORTCODE_LEHRGAENGE') && BIS_STANDORTCODE_LEHRGAENGE != '0')
+#####{
+#####	$standortcode = BIS_STANDORTCODE_LEHRGAENGE;
+#####}
+#####else
+#####{
+#####	echo "<H2>Standortcode f&uuml;r Lehrg&auml;nge fehlt.</H2>";
+#####	exit;
+#####}
 
 $datumobj=new datum();
 
@@ -178,6 +179,7 @@ if($result = $db->db_query($qry))
 	if($row = $db->db_fetch_object($result))
 	{
 		$stgart=$row->typ;
+		$standortcode = $row->standort_code;
 		$lgartcode = $row->lgartcode;
 		$qrylgart = "SELECT lgart_biscode FROM bis.tbl_lgartcode WHERE lgartcode=".$db->db_add_param($row->lgartcode);
 		if($result_lgartcode = $db->db_query($qrylgart))


### PR DESCRIPTION
Hallo Ösi, Alexei und liebes TW Team,

habe bei der BIS lehrgangsmeldung (manuelles generieren der XML über FAS) den Standort angepasst damit dieser aus der DB genommen wird und nicht aus der vilesci.config. Bei der Variante über die vilesci.config kann nur ein Standort für alle Lehrgänge definiert werden.
Würde das auch für euch so passen?

Danke und lg
Michael