### PR TITLE
FH Logo in der Mobilen Ansicht enfernen? und Suche in der mobilen Ansicht vergrößern

### DIFF
--- a/application/views/templates/CISHMVC-Header.php
+++ b/application/views/templates/CISHMVC-Header.php
@@ -16,7 +16,8 @@ if (!isset($menu)) {
 	<button id="nav-main-btn" class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#nav-main" aria-controls="nav-main" aria-expanded="false" aria-label="Toggle navigation">
 		<span class="navbar-toggler-icon"></span>
 	</button>
-	<a id="nav-logo" href="<?= site_url(''); ?>">
+
+	<a id="nav-logo" class="d-none d-md-block" href="<?= site_url(''); ?>">
 		<img src="<?= base_url('/public/images/logo-300x160.png'); ?>" alt="Logo">
 	</a>
 	<nav id="nav-main" class="offcanvas offcanvas-start bg-dark" tabindex="-1" aria-labelledby="nav-main-btn" data-bs-backdrop="false">

--- a/application/views/templates/CISHTML-Header.php
+++ b/application/views/templates/CISHTML-Header.php
@@ -32,7 +32,7 @@ if (!isset($menu)) {
 		<span class="navbar-toggler-icon"></span>
 	</button>
 	<fhc-searchbar id="nav-search" class=" fhc-searchbar w-100" @updatesearchtypes="updatesearchtypes" :selectedtypes="selectedtypes" :searchoptions="searchbaroptions" :searchfunction="searchfunction"></fhc-searchbar>	
-	<a id="nav-logo" href="<?= site_url(''); ?>">
+	<a id="nav-logo" class="d-none d-md-block" href="<?= site_url(''); ?>">
 		<img src="<?= base_url('/public/images/logo-300x160.png'); ?>" alt="Logo">
 	</a>
 	<nav id="nav-main" class="offcanvas offcanvas-start bg-dark" tabindex="-1" aria-labelledby="nav-main-btn" data-bs-backdrop="false">

--- a/public/css/Cis4/Cis.css
+++ b/public/css/Cis4/Cis.css
@@ -352,12 +352,12 @@ html {
     position: relative;
   }
   #nav-user-btn {
-    width: 100%;
+
   }
   #nav-user-btn img {
     object-fit: cover;
-    height: 1.5rem;
-    width: 1.5rem;
+    height: 2rem;
+    width: 2rem;
   }
   #nav-user-menu {
     position: relative !important;

--- a/public/js/components/Cis/Menu.js
+++ b/public/js/components/Cis/Menu.js
@@ -74,7 +74,7 @@ export default {
         <span class="navbar-toggler-icon"></span>
     </button>
 	<fhc-searchbar id="nav-search" class="fhc-searchbar w-100" :searchoptions="searchbaroptions" :searchfunction="searchfunction" :selectedtypes="selectedtypes"></fhc-searchbar>
-    <a id="nav-logo" :href="rootUrl">
+    <a id="nav-logo" class="d-none d-md-block" :href="rootUrl">
         <img :src="logoUrl" alt="Logo">
     </a>
 	<button id="nav-user-btn" class="btn btn-link rounded-0" type="button" data-bs-toggle="collapse" data-bs-target="#nav-user-menu" aria-expanded="false" aria-controls="nav-user-menu">


### PR DESCRIPTION
add bootstrap class to only show fh logo in header on medium and greater displays; adjusted nav-user-btn css under mobile breakpoint to just take space of contained img and let searchbar flex growth apply to leftover width;